### PR TITLE
fixed grad check for pytorch 1.9

### DIFF
--- a/lietorch/gradcheck.py
+++ b/lietorch/gradcheck.py
@@ -1,6 +1,14 @@
 import torch
+
+TORCH_MAJOR = int(torch.__version__.split('.')[0])
+TORCH_MINOR = int(torch.__version__.split('.')[1])
+
 from torch.types import _TensorOrTensors
-from torch._six import container_abcs, istuple
+if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
+    from torch._six import container_abcs, istuple
+else:
+    import collections.abc as container_abcs
+
 import torch.testing
 from torch.overrides import is_tensor_like
 from itertools import product
@@ -203,12 +211,18 @@ def get_analytical_jacobian(input, output, nondet_tol=0.0, grad_out=1.0):
 
 
 def _as_tuple(x):
-    if istuple(x):
+    if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
+        b_tuple = istuple(x)  
+    else:
+        b_tuple = isinstance(x, tuple)
+    
+    if b_tuple:
         return x
     elif isinstance(x, list):
         return tuple(x)
     else:
         return x,
+    
 
 
 def _differentiable_outputs(x):


### PR DESCRIPTION
Hi @zachteed 

Thanks for your great work! There is an offending commit (https://github.com/pytorch/pytorch/commit/58eb23378f2a376565a66ac32c93a316c45b6131) in torch 1.9.0 that breaks the testing functions. I added some sanity checks to make sure it runs properly. Since in the requirement there is no restriction of the torch version, this may help whoever uses the library.

Let me know!