### PR TITLE
Add a pyproject for PEP517 and PEP518.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools", "torch>=2.6.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lietorch"
+version = "0.2" 
+description = "Lie Groups for PyTorch"
+authors = [
+    { name="teedrz", email="zachteed@gmail.com" }
+]
+license = { text = "BSD-3-Clause" }
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "torch>=2.6.0",
+    "numpy<2",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ description = "Lie Groups for PyTorch"
 authors = [
     { name="teedrz", email="zachteed@gmail.com" }
 ]
+version = "0.2"
+description = "Lie Groups for PyTorch"
 license = { text = "BSD-3-Clause" }
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
### Issue

Current project is not compatible with the specification [PEP 517](https://peps.python.org/pep-0517/) and [PEP 518](https://peps.python.org/pep-0518/).

### Fixe

Add a pyproject.toml with correct details to matches the requirements and description of the project.
